### PR TITLE
mmanon: avoid CHKiRet for pthread mutex ops

### DIFF
--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -162,25 +162,8 @@ ENDfreeCnf
 
 BEGINcreateInstance
     CODESTARTcreateInstance;
-    int ipv4MutexInitialized = 0;
-    int ipv6MutexInitialized = 0;
-    if (pthread_mutex_init(&pData->ipv4Mutex, NULL) != 0) {
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-    ipv4MutexInitialized = 1;
-    if (pthread_mutex_init(&pData->ipv6Mutex, NULL) != 0) {
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-    ipv6MutexInitialized = 1;
-finalize_it:
-    if (iRet != RS_RET_OK) {
-        if (ipv6MutexInitialized != 0) {
-            pthread_mutex_destroy(&pData->ipv6Mutex);
-        }
-        if (ipv4MutexInitialized != 0) {
-            pthread_mutex_destroy(&pData->ipv4Mutex);
-        }
-    }
+    pthread_mutex_init(&pData->ipv4Mutex, NULL);
+    pthread_mutex_init(&pData->ipv6Mutex, NULL);
 ENDcreateInstance
 
 BEGINcreateWrkrInstance

--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -75,8 +75,10 @@ struct ipv6_int {
 typedef struct _instanceData {
     /*
      * Concurrency & Locking
-     * - ipv4Mutex protects the IPv4 consistency trie shared across workers.
-     * - ipv6Mutex protects the IPv6 and embedded-IPv4 consistency hash tables.
+     * - ipv4Mutex protects the IPv4 consistency trie shared across workers and
+     *   prevents concurrent insertions from corrupting the shared prefixes.
+     * - ipv6Mutex protects the IPv6 and embedded-IPv4 consistency hash tables
+     *   so worker lookups do not race with first-time allocations of entries.
      */
     pthread_mutex_t ipv4Mutex;
     pthread_mutex_t ipv6Mutex;

--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -162,12 +162,24 @@ ENDfreeCnf
 
 BEGINcreateInstance
     CODESTARTcreateInstance;
+    int ipv4MutexInitialized = 0;
+    int ipv6MutexInitialized = 0;
     if (pthread_mutex_init(&pData->ipv4Mutex, NULL) != 0) {
         ABORT_FINALIZE(RS_RET_ERR);
     }
+    ipv4MutexInitialized = 1;
     if (pthread_mutex_init(&pData->ipv6Mutex, NULL) != 0) {
-        pthread_mutex_destroy(&pData->ipv4Mutex);
         ABORT_FINALIZE(RS_RET_ERR);
+    }
+    ipv6MutexInitialized = 1;
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        if (ipv6MutexInitialized != 0) {
+            pthread_mutex_destroy(&pData->ipv6Mutex);
+        }
+        if (ipv4MutexInitialized != 0) {
+            pthread_mutex_destroy(&pData->ipv4Mutex);
+        }
     }
 ENDcreateInstance
 


### PR DESCRIPTION
## Summary
- handle pthread mutex initialization failures explicitly and clean up if the second mutex cannot be created
- treat mutex lock failures as rsyslog errors without using CHKiRet

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233983737c8333a7b2b110555e34d3)