### PR TITLE
mmanon: rename unique mode and cache numeric replacements

### DIFF
--- a/doc/source/configuration/modules/mmanon.rst
+++ b/doc/source/configuration/modules/mmanon.rst
@@ -50,6 +50,11 @@ Action Parameters
 Parameters starting with 'IPv4.' will configure IPv4 anonymization,
 while 'IPv6.' parameters do the same for IPv6 anonymization.
 
+Use the ``random-consistent-unique`` modes when it is important that each
+original address receives a distinct anonymized value. This mode behaves like
+``random-consistent`` but retries anonymization until the replacement does not
+collide with any previously generated alias.
+
 .. list-table::
    :widths: 30 70
    :header-rows: 1
@@ -212,12 +217,12 @@ Anonymizing only ipv6 addresses
 
 Another option is to only anonymize IPv6 addresses. When doing this you have to
 disable IPv4 anonymization. This example will lead to only IPv6 addresses anonymized
-(using the random-consistent mode).
+(using the random mode).
 
 .. code-block:: none
 
    module(load="mmanon")
    action(type="omfile" file="/path/to/non-anon.log")
-   action(type="mmanon" ipv4.enable="off" ipv6.anonmode="random-consistent")
+   action(type="mmanon" ipv4.enable="off" ipv6.anonmode="random")
    action(type="omfile" file="/path/to/anon.log")
 

--- a/doc/source/reference/parameters/mmanon-embeddedipv4-anonmode.rst
+++ b/doc/source/reference/parameters/mmanon-embeddedipv4-anonmode.rst
@@ -25,13 +25,17 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``random``, ``random-consistent``, and ``zero``.
+The available modes are ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 
 The modes ``random`` and ``random-consistent`` are very similar, in that they
 both anonymize IP addresses by randomizing the last bits (any number) of a given
 address. However, while ``random`` mode assigns a new random IP address for
 every address in a message, ``random-consistent`` will assign the same
 randomized address to every instance of the same original address.
+``random-consistent-unique`` extends the consistent mode by regenerating the
+alias until it is unique to prevent collisions between different input
+addresses.
 
 The default ``zero`` mode will do full anonymization of any number of bits and
 it will also normalize the address, so that no information about the original IP
@@ -48,7 +52,7 @@ Input usage
 .. code-block:: rsyslog
 
    module(load="mmanon")
-   action(type="mmanon" embeddedIpv4.anonMode="random")
+   action(type="mmanon" embeddedIpv4.anonMode="random-consistent-unique")
 
 See also
 --------

--- a/doc/source/reference/parameters/mmanon-ipv4-mode.rst
+++ b/doc/source/reference/parameters/mmanon-ipv4-mode.rst
@@ -25,8 +25,8 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``simple``, ``random``, ``random-consistent``, and
-``zero``.
+The available modes are ``simple``, ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 In simple mode, only octets as a whole can be anonymized and the length of the
 message is never changed. This means that when the last three octets of the
 address 10.1.12.123 are anonymized, the result will be 10.x.xx.xxx.
@@ -42,6 +42,9 @@ they both anonymize IP addresses by randomizing the last bits (any number)
 of a given address. However, while ``random`` mode assigns a new random IP
 address for every address in a message, ``random-consistent`` will assign
 the same randomized address to every instance of the same original address.
+``random-consistent-unique`` extends the consistent mode by regenerating the
+alias until it is unique so that no two different input addresses end up with
+the same anonymized value.
 
 The default ``zero`` mode will do full anonymization of any number of bits.
 It will also normalize the address, so that no information about the original
@@ -55,7 +58,7 @@ Input usage
 .. code-block:: rsyslog
 
    module(load="mmanon")
-   action(type="mmanon" ipv4.mode="random-consistent")
+   action(type="mmanon" ipv4.mode="random-consistent-unique")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/mmanon-ipv6-anonmode.rst
+++ b/doc/source/reference/parameters/mmanon-ipv6-anonmode.rst
@@ -25,13 +25,17 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``random``, ``random-consistent``, and ``zero``.
+The available modes are ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 
 The modes ``random`` and ``random-consistent`` are very similar, in that they
 both anonymize IP addresses by randomizing the last bits (any number) of a given
 address. However, while ``random`` mode assigns a new random IP address for
 every address in a message, ``random-consistent`` will assign the same
 randomized address to every instance of the same original address.
+``random-consistent-unique`` extends the consistent mode by regenerating the
+alias until it is unique so different inputs do not collide after
+anonymization.
 
 The default ``zero`` mode will do full anonymization of any number of bits and it
 will also normalize the address, so that no information about the original IP
@@ -48,7 +52,7 @@ Input usage
 .. code-block:: rsyslog
 
    module(load="mmanon")
-   action(type="mmanon" ipv6.anonMode="random-consistent")
+   action(type="mmanon" ipv6.anonMode="random-consistent-unique")
 
 See also
 --------


### PR DESCRIPTION
## Summary
- rename the unique consistent anonymization option to random-consistent-unique and refresh documentation, restoring the IPv6-only example to the standard random mode
- rename anonymization caches for clarity and track generated replacements as numeric keys before formatting
- store unique replacement sets for IPv4/IPv6/embedded IPv4 using integer keys to avoid repeated string conversions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c89cf5ec83339c23e177530bcbd7)