### PR TITLE
Refine mmanon random-consistent unique tracking

### DIFF
--- a/doc/source/reference/parameters/mmanon-embeddedipv4-anonmode.rst
+++ b/doc/source/reference/parameters/mmanon-embeddedipv4-anonmode.rst
@@ -25,13 +25,19 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``random``, ``random-consistent``, and ``zero``.
+The available modes are ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 
 The modes ``random`` and ``random-consistent`` are very similar, in that they
 both anonymize IP addresses by randomizing the last bits (any number) of a given
 address. However, while ``random`` mode assigns a new random IP address for
 every address in a message, ``random-consistent`` will assign the same
 randomized address to every instance of the same original address.
+``random-consistent-unique`` builds on that behavior and guarantees that no
+two distinct original addresses share the same anonymized result. It may
+take longer to generate addresses because a replacement is retried until an
+unused randomized value is found; this effect grows as more unique IPs are
+processed.
 
 The default ``zero`` mode will do full anonymization of any number of bits and
 it will also normalize the address, so that no information about the original IP

--- a/doc/source/reference/parameters/mmanon-ipv4-mode.rst
+++ b/doc/source/reference/parameters/mmanon-ipv4-mode.rst
@@ -25,8 +25,8 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``simple``, ``random``, ``random-consistent``, and
-``zero``.
+The available modes are ``simple``, ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 In simple mode, only octets as a whole can be anonymized and the length of the
 message is never changed. This means that when the last three octets of the
 address 10.1.12.123 are anonymized, the result will be 10.x.xx.xxx.
@@ -42,6 +42,11 @@ they both anonymize IP addresses by randomizing the last bits (any number)
 of a given address. However, while ``random`` mode assigns a new random IP
 address for every address in a message, ``random-consistent`` will assign
 the same randomized address to every instance of the same original address.
+``random-consistent-unique`` builds on that behavior and guarantees that no
+two distinct original addresses share the same anonymized result. It may
+take longer to generate addresses because a replacement is retried until an
+unused randomized value is found; this effect grows as more unique IPs are
+processed.
 
 The default ``zero`` mode will do full anonymization of any number of bits.
 It will also normalize the address, so that no information about the original

--- a/doc/source/reference/parameters/mmanon-ipv6-anonmode.rst
+++ b/doc/source/reference/parameters/mmanon-ipv6-anonmode.rst
@@ -25,13 +25,19 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``random``, ``random-consistent``, and ``zero``.
+The available modes are ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 
 The modes ``random`` and ``random-consistent`` are very similar, in that they
 both anonymize IP addresses by randomizing the last bits (any number) of a given
 address. However, while ``random`` mode assigns a new random IP address for
 every address in a message, ``random-consistent`` will assign the same
 randomized address to every instance of the same original address.
+``random-consistent-unique`` builds on that behavior and guarantees that no
+two distinct original addresses share the same anonymized result. It may
+take longer to generate addresses because a replacement is retried until an
+unused randomized value is found; this effect grows as more unique IPs are
+processed.
 
 The default ``zero`` mode will do full anonymization of any number of bits and it
 will also normalize the address, so that no information about the original IP


### PR DESCRIPTION
## Summary
- rename the random-consistent mapping and uniqueness hash tables to reflect their purpose
- store randomized IPv4 and IPv6 addresses as numeric keys when enforcing uniqueness to avoid string conversions
- align the random-consistent-unique documentation across IPv4, IPv6, and embedded IPv4 parameter pages with identical wording

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407c3c1d0083338496e970a4b5626c)