### PR TITLE
tests: harden chkseq extra-data parsing

### DIFF
--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -127,26 +127,12 @@ int main(int argc, char *argv[]) {
 
     for (i = start; i <= end; i += increment) {
         if (bHaveExtraData) {
+            edLen = 0;
+            edBuf[0] = '\0';
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                 scanfOK = 0;
             } else {
                 scanfOK = sscanf(ioBuf, "%d,%d,%s\n", &val, &edLen, edBuf) == 3 ? 1 : 0;
-            }
-            if (edLen != (int)strlen(edBuf)) {
-                if (bAnticipateTruncation == 1) {
-                    if (edLen < (int)strlen(edBuf)) {
-                        printf(
-                            "extra data length specified %d, but actually is %ld in"
-                            " record %d (truncation was anticipated, but payload should"
-                            " have been smaller than data-length, not larger)\n",
-                            edLen, (long)strlen(edBuf), i);
-                        exit(1);
-                    }
-                } else {
-                    printf("extra data length specified %d, but actually is %ld in record %d\n", edLen,
-                           (long)strlen(edBuf), i);
-                    exit(1);
-                }
             }
         } else {
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
@@ -158,6 +144,22 @@ int main(int argc, char *argv[]) {
         if (!scanfOK) {
             printf("scanf error in index i=%d\n", i);
             exit(1);
+        }
+        if (bHaveExtraData && edLen != (int)strlen(edBuf)) {
+            if (bAnticipateTruncation == 1) {
+                if (edLen < (int)strlen(edBuf)) {
+                    printf(
+                        "extra data length specified %d, but actually is %ld in"
+                        " record %d (truncation was anticipated, but payload should"
+                        " have been smaller than data-length, not larger)\n",
+                        edLen, (long)strlen(edBuf), i);
+                    exit(1);
+                }
+            } else {
+                printf("extra data length specified %d, but actually is %ld in record %d\n", edLen, (long)strlen(edBuf),
+                       i);
+                exit(1);
+            }
         }
         while (val > i && lostok > 0) {
             --lostok;
@@ -192,35 +194,42 @@ int main(int argc, char *argv[]) {
             i = end;
             while (!feof(fp)) {
                 if (bHaveExtraData) {
+                    edLen = 0;
+                    edBuf[0] = '\0';
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
                         scanfOK = sscanf(ioBuf, "%d,%d,%s\n", &val, &edLen, edBuf) == 3 ? 1 : 0;
-                    }
-                    if (edLen != (int)strlen(edBuf)) {
-                        if (bAnticipateTruncation == 1) {
-                            if (edLen < (int)strlen(edBuf)) {
-                                printf(
-                                    "extra data length specified %d, but "
-                                    "actually is %ld in record %d (truncation was"
-                                    " anticipated, but payload should have been "
-                                    "smaller than data-length, not larger)\n",
-                                    edLen, (long)strlen(edBuf), i);
-                                exit(1);
-                            }
-                        } else {
-                            printf(
-                                "extra data length specified %d, but actually "
-                                "is %ld in record %d\n",
-                                edLen, (long)strlen(edBuf), i);
-                            exit(1);
-                        }
                     }
                 } else {
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
                         scanfOK = sscanf(ioBuf, "%d\n", &val) == 1 ? 1 : 0;
+                    }
+                }
+
+                if (!scanfOK) {
+                    printf("scanf error in index i=%d\n", i);
+                    exit(1);
+                }
+                if (bHaveExtraData && edLen != (int)strlen(edBuf)) {
+                    if (bAnticipateTruncation == 1) {
+                        if (edLen < (int)strlen(edBuf)) {
+                            printf(
+                                "extra data length specified %d, but "
+                                "actually is %ld in record %d (truncation was"
+                                " anticipated, but payload should have been "
+                                "smaller than data-length, not larger)\n",
+                                edLen, (long)strlen(edBuf), i);
+                            exit(1);
+                        }
+                    } else {
+                        printf(
+                            "extra data length specified %d, but actually "
+                            "is %ld in record %d\n",
+                            edLen, (long)strlen(edBuf), i);
+                        exit(1);
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- Prevent reads of `edLen`/`edBuf` when `fgets`/`sscanf` fail in `chkseq` (-E mode) to avoid uninitialized/stale-data checks.
- Make error reporting deterministic on EOF or malformed lines instead of relying on previously parsed values.
- Apply the same safety to the trailing-duplicate scan so both paths behave consistently.

### Description
- Reset `edLen` to `0` and `edBuf[0]` to `\0` before each read when `-E` is enabled so previous contents cannot be reused.
- Move extra-data length validation behind the `fgets`+`sscanf` success gate (`scanfOK`) in the main loop so length checks only run after a successful parse.
- Apply the same `scanfOK` gating and reset behavior in the duplicate-tail scan loop used when `-d` is specified.
- No change to behavior for well-formed input lines; this only hardens error handling for EOF/parse failures.

### Testing
- Ran code formatting normalization with `devtools/format-code.sh`, which completed successfully.
- No testbench scripts were executed in this change (no automated `./tests/*.sh` run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724f2984548333880ddeb8c5fcbd4f)