### PR TITLE
tests: guard chkseq extra data parsing

### DIFF
--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                 scanfOK = 0;
             } else {
-                scanfOK = sscanf(ioBuf, "%d,%d,%s\n", &val, &edLen, edBuf) == 3 ? 1 : 0;
+                scanfOK = sscanf(ioBuf, "%d,%d,%511999s\n", &val, &edLen, edBuf) == 3;
             }
             if (scanfOK && edLen != (int)strlen(edBuf)) {
                 if (bAnticipateTruncation == 1) {
@@ -199,7 +199,7 @@ int main(int argc, char *argv[]) {
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
-                        scanfOK = sscanf(ioBuf, "%d,%d,%s\n", &val, &edLen, edBuf) == 3 ? 1 : 0;
+                        scanfOK = sscanf(ioBuf, "%d,%d,%511999s\n", &val, &edLen, edBuf) == 3;
                     }
                     if (scanfOK && edLen != (int)strlen(edBuf)) {
                         if (bAnticipateTruncation == 1) {

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -48,13 +48,9 @@
 #endif
 
 #define EDBUF_SIZE (500 * 1024)
-#define EDBUF_SCAN_WIDTH 511999
+#define EDBUF_SCAN_WIDTH (EDBUF_SIZE - 1)
 #define SCN_WIDTH_STR(x) #x
 #define SCN_WIDTH(x) SCN_WIDTH_STR(x)
-
-#if EDBUF_SCAN_WIDTH != (EDBUF_SIZE - 1)
-    #error "EDBUF_SCAN_WIDTH must match EDBUF_SIZE - 1"
-#endif
 
 int main(int argc, char *argv[]) {
     FILE *fp;

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -127,12 +127,14 @@ int main(int argc, char *argv[]) {
 
     for (i = start; i <= end; i += increment) {
         if (bHaveExtraData) {
+            edLen = 0;
+            edBuf[0] = '\0';
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                 scanfOK = 0;
             } else {
                 scanfOK = sscanf(ioBuf, "%d,%d,%s\n", &val, &edLen, edBuf) == 3 ? 1 : 0;
             }
-            if (edLen != (int)strlen(edBuf)) {
+            if (scanfOK && edLen != (int)strlen(edBuf)) {
                 if (bAnticipateTruncation == 1) {
                     if (edLen < (int)strlen(edBuf)) {
                         printf(
@@ -192,12 +194,14 @@ int main(int argc, char *argv[]) {
             i = end;
             while (!feof(fp)) {
                 if (bHaveExtraData) {
+                    edLen = 0;
+                    edBuf[0] = '\0';
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
                         scanfOK = sscanf(ioBuf, "%d,%d,%s\n", &val, &edLen, edBuf) == 3 ? 1 : 0;
                     }
-                    if (edLen != (int)strlen(edBuf)) {
+                    if (scanfOK && edLen != (int)strlen(edBuf)) {
                         if (bAnticipateTruncation == 1) {
                             if (edLen < (int)strlen(edBuf)) {
                                 printf(

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -48,8 +48,13 @@
 #endif
 
 #define EDBUF_SIZE (500 * 1024)
+#define EDBUF_SCAN_WIDTH 511999
 #define SCN_WIDTH_STR(x) #x
 #define SCN_WIDTH(x) SCN_WIDTH_STR(x)
+
+#if EDBUF_SCAN_WIDTH != (EDBUF_SIZE - 1)
+    #error "EDBUF_SCAN_WIDTH must match EDBUF_SIZE - 1"
+#endif
 
 int main(int argc, char *argv[]) {
     FILE *fp;
@@ -136,7 +141,7 @@ int main(int argc, char *argv[]) {
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                 scanfOK = 0;
             } else {
-                scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SIZE - 1) "s\n", &val, &edLen, edBuf) == 3;
+                scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SCAN_WIDTH) "s\n", &val, &edLen, edBuf) == 3;
             }
             if (scanfOK && edLen != (int)strlen(edBuf)) {
                 if (bAnticipateTruncation == 1) {
@@ -203,7 +208,7 @@ int main(int argc, char *argv[]) {
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
-                        scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SIZE - 1) "s\n", &val, &edLen, edBuf) == 3;
+                        scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SCAN_WIDTH) "s\n", &val, &edLen, edBuf) == 3;
                     }
                     if (scanfOK && edLen != (int)strlen(edBuf)) {
                         if (bAnticipateTruncation == 1) {

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -48,9 +48,6 @@
 #endif
 
 #define EDBUF_SIZE (500 * 1024)
-#define EDBUF_SCAN_WIDTH (EDBUF_SIZE - 1)
-#define SCN_WIDTH_STR(x) #x
-#define SCN_WIDTH(x) SCN_WIDTH_STR(x)
 
 int main(int argc, char *argv[]) {
     FILE *fp;
@@ -71,7 +68,10 @@ int main(int argc, char *argv[]) {
     int edLen; /* length of extra data */
     static char edBuf[EDBUF_SIZE]; /* buffer for extra data (pretty large to be on the save side...) */
     static char ioBuf[sizeof(edBuf) + 1024];
+    char extraFmt[64];
     char *file = NULL;
+
+    snprintf(extraFmt, sizeof(extraFmt), "%%d,%%d,%%%zus\n", sizeof(edBuf) - 1);
 
     while ((opt = getopt(argc, argv, "i:e:f:ds:vm:ET")) != EOF) {
         switch ((char)opt) {
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                 scanfOK = 0;
             } else {
-                scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SCAN_WIDTH) "s\n", &val, &edLen, edBuf) == 3;
+                scanfOK = sscanf(ioBuf, extraFmt, &val, &edLen, edBuf) == 3;
             }
             if (scanfOK && edLen != (int)strlen(edBuf)) {
                 if (bAnticipateTruncation == 1) {
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
-                        scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SCAN_WIDTH) "s\n", &val, &edLen, edBuf) == 3;
+                        scanfOK = sscanf(ioBuf, extraFmt, &val, &edLen, edBuf) == 3;
                     }
                     if (scanfOK && edLen != (int)strlen(edBuf)) {
                         if (bAnticipateTruncation == 1) {

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -47,6 +47,10 @@
     #include <getopt.h>
 #endif
 
+#define EDBUF_SIZE (500 * 1024)
+#define SCN_WIDTH_STR(x) #x
+#define SCN_WIDTH(x) SCN_WIDTH_STR(x)
+
 int main(int argc, char *argv[]) {
     FILE *fp;
     int val;
@@ -64,7 +68,7 @@ int main(int argc, char *argv[]) {
     int increment = 1;
     int reachedEOF;
     int edLen; /* length of extra data */
-    static char edBuf[500 * 1024]; /* buffer for extra data (pretty large to be on the save side...) */
+    static char edBuf[EDBUF_SIZE]; /* buffer for extra data (pretty large to be on the save side...) */
     static char ioBuf[sizeof(edBuf) + 1024];
     char *file = NULL;
 
@@ -132,7 +136,7 @@ int main(int argc, char *argv[]) {
             if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                 scanfOK = 0;
             } else {
-                scanfOK = sscanf(ioBuf, "%d,%d,%511999s\n", &val, &edLen, edBuf) == 3;
+                scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SIZE - 1) "s\n", &val, &edLen, edBuf) == 3;
             }
             if (scanfOK && edLen != (int)strlen(edBuf)) {
                 if (bAnticipateTruncation == 1) {
@@ -199,7 +203,7 @@ int main(int argc, char *argv[]) {
                     if (fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
                         scanfOK = 0;
                     } else {
-                        scanfOK = sscanf(ioBuf, "%d,%d,%511999s\n", &val, &edLen, edBuf) == 3;
+                        scanfOK = sscanf(ioBuf, "%d,%d,%" SCN_WIDTH(EDBUF_SIZE - 1) "s\n", &val, &edLen, edBuf) == 3;
                     }
                     if (scanfOK && edLen != (int)strlen(edBuf)) {
                         if (bAnticipateTruncation == 1) {


### PR DESCRIPTION
### Motivation
- Prevent undefined reads when `chkseq` runs with `-E` and `fgets`/`sscanf` fail or hit EOF, which could leave `edLen`/`edBuf` stale.
- Harden the duplicate-tail scan path as it exercised the same unsafe checks.

### Description
- Reset `edLen` to `0` and `edBuf[0] = '\0'` before each read in the main loop and the duplicate tail scan in `tests/chkseq.c`.
- Only perform the `edLen != strlen(edBuf)` validation when the parse succeeded by gating it on `scanfOK`.
- No other behavior changes; this only avoids using uninitialized/stale values on parse failure or EOF.

### Testing
- Ran code formatting with `devtools/format-code.sh`, and formatting completed successfully.
- No runtime unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976085c70a88333bf49581438b6c8c1)